### PR TITLE
Disable clang-tidy

### DIFF
--- a/cc/tidy.go
+++ b/cc/tidy.go
@@ -82,7 +82,7 @@ func (tidy *tidyFeature) flags(ctx ModuleContext, flags Flags) Flags {
 		return flags
 	}
 
-	flags.Tidy = true
+	flags.Tidy = false
 
 	// Add global WITH_TIDY_FLAGS and local tidy_flags.
 	withTidyFlags := ctx.Config().Getenv("WITH_TIDY_FLAGS")


### PR DESCRIPTION
Running clang-tidy on all the AOSP code is of little use for us, but it
takes a substantial amount of build time. Disable it to reduce build
times for native code.

Change-Id: Idc3d97bf0a08db31e66ab6ad018749575906ca1e