### PR TITLE
use -fwrapv when signed overflow checking is off

### DIFF
--- a/cc/cc.go
+++ b/cc/cc.go
@@ -2022,6 +2022,8 @@ func (c *Module) GenerateAndroidBuildActions(actx android.ModuleContext) {
 	}
 	if c.sanitize != nil {
 		flags = c.sanitize.flags(ctx, flags)
+	} else {
+		flags.Local.CFlags = append(flags.Local.CFlags, "-fwrapv")
 	}
 	if c.coverage != nil {
 		flags, deps = c.coverage.flags(ctx, flags, deps)

--- a/cc/cc_test.go
+++ b/cc/cc_test.go
@@ -4844,7 +4844,7 @@ func TestIncludeDirectoryOrdering(t *testing.T) {
 	conly := []string{"-fPIC", "${config.CommonGlobalConlyflags}"}
 	cppOnly := []string{"-fPIC", "${config.CommonGlobalCppflags}", "${config.DeviceGlobalCppflags}", "${config.ArmCppflags}"}
 
-	cflags := []string{"-Werror", "-std=candcpp"}
+	cflags := []string{"-Werror", "-std=candcpp", "-fwrapv"}
 	cstd := []string{"-std=gnu11", "-std=conly"}
 	cppstd := []string{"-std=gnu++17", "-std=cpp", "-fno-rtti"}
 

--- a/cc/sanitize.go
+++ b/cc/sanitize.go
@@ -751,8 +751,22 @@ func toDisableUnsignedShiftBaseChange(flags []string) bool {
 
 func (s *sanitize) flags(ctx ModuleContext, flags Flags) Flags {
 	if !s.Properties.SanitizerEnabled && !s.Properties.UbsanRuntimeDep {
+		flags.Local.CFlags = append(flags.Local.CFlags, "-fwrapv")
 		return flags
 	}
+
+	wrapv := true
+	for _, san := range s.Properties.Sanitizers {
+		if san == "signed-integer-overflow" || san == "integer" || san == "undefined" {
+			wrapv = false
+			break
+		}
+	}
+
+	if wrapv {
+		flags.Local.CFlags = append(flags.Local.CFlags, "-fwrapv")
+	}
+
 	sanProps := &s.Properties.SanitizeMutated
 
 	if Bool(sanProps.Address) {


### PR DESCRIPTION
13: 62bea80ab9189b81a8728b71b284b7afba9d5969

Depends on: https://github.com/GrapheneOS/platform_prebuilts_abi-dumps_vndk/pull/1